### PR TITLE
Refine <a> border reset in product pages

### DIFF
--- a/css/md.css
+++ b/css/md.css
@@ -94,7 +94,7 @@ article p em:last-of-type { /* attribution text on code-of-conduct page  */
     border-bottom: none;
 }
 
-#product p > a {
+#product p > a[href *= "screenshot"]{
     border-bottom: none;
 }
 


### PR DESCRIPTION
Refine the <a> border reset for product pages to only apply to <a> elements with hrefs pointing at something with "screenshot" in them.